### PR TITLE
Add `edge_width` option to `create_pmap()` to choose which attribute is used for edge width.

### DIFF
--- a/R/adjust_edge_label.R
+++ b/R/adjust_edge_label.R
@@ -33,10 +33,10 @@ adjust_edge_label <- function(p, label = c(
   edge_label_value <- switch(
     label,
     amount = edges$amount,
-    max_duration = edges$max_duration,
-    mean_duration = edges$mean_duration,
-    median_duration = edges$median_duration,
-    min_duration = edges$min_duration
+    max_duration = format_duration(edges$max_duration),
+    mean_duration = format_duration(edges$mean_duration),
+    median_duration = format_duration(edges$median_duration),
+    min_duration = format_duration(edges$min_duration)
   )
 
   p <- DiagrammeR::set_edge_attrs(p, edge_attr = "label", values = paste0("   ", edge_label_value, "   "))

--- a/R/create_pmap.R
+++ b/R/create_pmap.R
@@ -1,22 +1,10 @@
 #' @title Create the process map from event log directly
-#' @usage create_pmap(
-#'    eventlog,
-#'    distinct_case = FALSE,
-#'    distinct_repeated_activities = FALSE,
-#'    target_categories = NULL,
-#'    edge_label = c(
-#'      "amount",
-#'      "mean_duration",
-#'      "median_duration",
-#'      "max_duration",
-#'      "min_duration"
-#'    )
-#'  )
 #' @param eventlog Event log
 #' @param distinct_case Whether should count distinct case only. Default is `FALSE`.
 #' @param distinct_repeated_activities Whether should distinct repeat activities. Default is `FALSE`, which means the repeated activity will be treated as same node. If it's `TRUE`, the name of the activity will be attached with the sequence number of occurance of the activity.
 #' @param target_categories A vector contains the target activity categories
 #' @param edge_label Specify which attribute is used for the edge label.
+#' @param edge_width Specify which attribute is used for the edge width.
 #' @description Create the process map by analyzing the given `eventlog` and extract the nodes by `generate_nodes()` and edges by `generate_edges()`.
 #' @details
 #' ```R
@@ -103,6 +91,13 @@ create_pmap <- function(
     "median_duration",
     "max_duration",
     "min_duration"
+  ),
+  edge_width = c(
+    "amount",
+    "mean_duration",
+    "median_duration",
+    "max_duration",
+    "min_duration"
   )
 ) {
   # Make R Cmd Check happy
@@ -139,6 +134,6 @@ create_pmap <- function(
     stop("Generated graph contains no edge.")
   }
 
-  p <- create_pmap_graph(nodes, edges, target_categories, edge_label)
+  p <- create_pmap_graph(nodes, edges, target_categories, edge_label, edge_width)
   return(p)
 }

--- a/man/create_pmap.Rd
+++ b/man/create_pmap.Rd
@@ -5,18 +5,15 @@
 \title{Create the process map from event log directly}
 \usage{
 create_pmap(
-   eventlog,
-   distinct_case = FALSE,
-   distinct_repeated_activities = FALSE,
-   target_categories = NULL,
-   edge_label = c(
-     "amount",
-     "mean_duration",
-     "median_duration",
-     "max_duration",
-     "min_duration"
-   )
- )
+  eventlog,
+  distinct_case = FALSE,
+  distinct_repeated_activities = FALSE,
+  target_categories = NULL,
+  edge_label = c("amount", "mean_duration", "median_duration", "max_duration",
+    "min_duration"),
+  edge_width = c("amount", "mean_duration", "median_duration", "max_duration",
+    "min_duration")
+)
 }
 \arguments{
 \item{eventlog}{Event log}
@@ -28,6 +25,8 @@ create_pmap(
 \item{target_categories}{A vector contains the target activity categories}
 
 \item{edge_label}{Specify which attribute is used for the edge label.}
+
+\item{edge_width}{Specify which attribute is used for the edge width.}
 }
 \description{
 Create the process map by analyzing the given \code{eventlog} and extract the nodes by \code{generate_nodes()} and edges by \code{generate_edges()}.

--- a/man/create_pmap_graph.Rd
+++ b/man/create_pmap_graph.Rd
@@ -5,17 +5,14 @@
 \title{Create the activity graph by given nodes and edges.}
 \usage{
 create_pmap_graph(
-   nodes,
-   edges,
-   target_categories = NULL,
-   edge_label = c(
-     "amount",
-     "mean_duration",
-     "median_duration",
-     "max_duration",
-     "min_duration"
-   )
- )
+  nodes,
+  edges,
+  target_categories = NULL,
+  edge_label = c("amount", "mean_duration", "median_duration", "max_duration",
+    "min_duration"),
+  edge_width = c("amount", "mean_duration", "median_duration", "max_duration",
+    "min_duration")
+)
 }
 \arguments{
 \item{nodes}{Event list, it should be a \code{data.frame} containing following columns:
@@ -34,6 +31,8 @@ create_pmap_graph(
 \item{target_categories}{A vector contains the target activity categories}
 
 \item{edge_label}{Specify which attribute is used for the edge label.}
+
+\item{edge_width}{Specify which attribute is used for the edge width.}
 }
 \description{
 Create the process map graph by specify the nodes and edges

--- a/tests/testthat/test_create_pmap.R
+++ b/tests/testthat/test_create_pmap.R
@@ -105,10 +105,11 @@ test_that("create_pmap() should handle names with SPACE padding", {
   expect_equal(edges$amount, 2)
 
   # test duration
-  expect_equal(edges$mean_duration, "1.07 weeks")
-  expect_equal(edges$median_duration, "1.07 weeks")
-  expect_equal(edges$max_duration, "2 weeks")
-  expect_equal(edges$min_duration, "1 days")
+  expect_equal(edges$mean_duration, as.difftime(7.5, units = "days"))
+  expect_equal(edges$median_duration, as.difftime(7.5, units = "days"))
+  expect_equal(edges$max_duration, as.difftime(14, units = "days"))
+  expect_equal(edges$min_duration, as.difftime(1, units = "days"))
+  expect_equal(edges$tooltip, "from: a\nto: b\namount: 2\nmean_duration: 1.07 weeks\nmedian_duration: 1.07 weeks\nmax_duration: 2 weeks\nmin_duration: 1 days")
 })
 
 test_that("create_pmap() should distinct repeated activities if `distinct_repeated_activities`", {
@@ -166,4 +167,28 @@ test_that("create_pmap() should distinct repeated activities if `distinct_repeat
   expect_equal(nodes$name, c("a (1)", "a (2)", "b (1)", "b (2)"))
   expect_equal(nodes$type, c("a", "a", "b", "b"))
   expect_equal(nodes$amount, c(2, 1, 3, 1))
+})
+
+test_that("create_pmap() should handle the eventlog without timestamp", {
+  p <- create_pmap(
+    data.frame(
+      case_id = c("c1", "c1", "c1", "c2", "c2", "c3", "c3"),
+      activity = c("a", "b", "a", "b", "b", "a", "b"),
+      category = c("campaign", "sale", "campaign", "sale", "sale", "campaign", "sale"),
+      stringsAsFactors = FALSE
+    )
+  )
+
+  edges <- DiagrammeR::get_edge_df(p)
+
+  expect_equal(nrow(edges), 3)
+  expect_equal(edges$from, c(1, 2, 2))
+  expect_equal(edges$to, c(2, 1, 2))
+  expect_equal(edges$amount, c(2, 1, 1))
+
+  # test duration
+  expect_equal("mean_duration" %in% colnames(edges), FALSE)
+  expect_equal("median_duration" %in% colnames(edges), FALSE)
+  expect_equal("max_duration" %in% colnames(edges), FALSE)
+  expect_equal("min_duration" %in% colnames(edges), FALSE)
 })

--- a/tests/testthat/test_create_pmap_graph.R
+++ b/tests/testthat/test_create_pmap_graph.R
@@ -60,3 +60,35 @@ test_that("create_pmap_graph() should assign `0` to `NA` in `inbound` and `outbo
   expect_true(!any(is.na(node_df$amount)))
 })
 
+
+test_that("create_pmap_graph() should handle the edge without duration", {
+  p <- create_pmap_graph(
+    nodes = data.frame(
+      name = c("a", "b", "c", "d", "e"),
+      category = c("campaign", "campaign", "campaign", "sale", "sale"),
+      amount = c(10, 30, 20, 40, NA),
+      stringsAsFactors = FALSE
+    ),
+    edges = data.frame(
+      from = c("a", "b", "b", "a"),
+      to = c("b", "c", "d", "e"),
+      amount = c(10, 30, 20, 40),
+      stringsAsFactors = FALSE
+    ),
+    target_categories = c("sale")
+  )
+
+  # as no timestamp are given, so no `xxx_duration` should exist.
+  edge_df <- DiagrammeR::get_edge_df(p)
+  expect_equal("mean_duration" %in% colnames(edge_df), FALSE)
+  expect_equal("median_duration" %in% colnames(edge_df), FALSE)
+  expect_equal("max_duration" %in% colnames(edge_df), FALSE)
+  expect_equal("min_duration" %in% colnames(edge_df), FALSE)
+
+  expect_equal(edge_df$tooltip, c(
+    "from: a\nto: b\namount: 10",
+    "from: b\nto: c\namount: 30",
+    "from: b\nto: d\namount: 20",
+    "from: a\nto: e\namount: 40"
+  ))
+})

--- a/tests/testthat/test_create_pmap_graph.R
+++ b/tests/testthat/test_create_pmap_graph.R
@@ -1,6 +1,6 @@
 context("create_pmap_graph()")
 
-test_that("create_pmap_graph()", {
+test_that("create_pmap_graph() on basic graph", {
   eventlog <- generate_eventlog(
     size_of_eventlog = 10000,
     number_of_cases = 1000,
@@ -24,13 +24,22 @@ test_that("create_pmap_graph()", {
   expect_true(all(c("from", "to", "amount", "mean_duration", "max_duration", "min_duration") %in% colnames(edges)))
   expect_gt(nrow(edges), 100)
 
+  # print("> edges (generate_edges):")
   # print(str(edges))
 
   # print("create_pmap_graph()")
   p <- create_pmap_graph(nodes, edges, target_categories = c("sale"))
 
   edges_from_graph <- DiagrammeR::get_edge_df(p)
+  # print("> edges_from_graph:")
+  # print(str(edges_from_graph))
+
   expect_equal(nrow(edges), nrow(edges_from_graph))
+
+  # check default label
+  # print(str(edges_from_graph$label))
+  # print(paste("sum():", sum(edges_from_graph$label == paste0("   ", edges$amount, "   "))))
+  expect_equal(sum(edges_from_graph$label == paste0("   ", edges$amount, "   ")), nrow(edges))
 
   # print("render_graph()")
   expect_true(!any(is.null(render_pmap(p))))

--- a/tests/testthat/test_generate_edges.R
+++ b/tests/testthat/test_generate_edges.R
@@ -18,10 +18,10 @@ test_that("generate_edges() should handle minimal eventlog", {
   expect_equal(edges$amount, 1)
 
   # test duration
-  expect_equal(edges$mean_duration, "2.71 weeks")
-  expect_equal(edges$median_duration, "2.71 weeks")
-  expect_equal(edges$max_duration, "2.71 weeks")
-  expect_equal(edges$min_duration, "2.71 weeks")
+  expect_equal(edges$mean_duration, as.difftime(19, units = "days"))
+  expect_equal(edges$median_duration, as.difftime(19, units = "days"))
+  expect_equal(edges$max_duration, as.difftime(19, units = "days"))
+  expect_equal(edges$min_duration, as.difftime(19, units = "days"))
 })
 
 test_that("generate_edges() should handle eventlog without specifies 'target_categories'", {
@@ -38,10 +38,10 @@ test_that("generate_edges() should handle eventlog without specifies 'target_cat
   expect_equal(nrow(edges), 1)
 
     # test duration
-  expect_equal(edges$mean_duration, "2.71 weeks")
-  expect_equal(edges$median_duration, "2.71 weeks")
-  expect_equal(edges$max_duration, "2.71 weeks")
-  expect_equal(edges$min_duration, "2.71 weeks")
+  expect_equal(edges$mean_duration, as.difftime(19, units = "days"))
+  expect_equal(edges$median_duration, as.difftime(19, units = "days"))
+  expect_equal(edges$max_duration, as.difftime(19, units = "days"))
+  expect_equal(edges$min_duration, as.difftime(19, units = "days"))
 })
 
 test_that("generate_edges() should handle eventlog without edge reaches 'target_categories'", {
@@ -98,10 +98,10 @@ test_that("generate_edges() should count every paths if 'distinct_case' is not s
   expect_equal(edges$amount, 3)
 
     # test duration
-  expect_equal(edges$mean_duration, "5 days")
-  expect_equal(edges$median_duration, "4 days")
-  expect_equal(edges$max_duration, "1.43 weeks")
-  expect_equal(edges$min_duration, "1 days")
+  expect_equal(edges$mean_duration, as.difftime(5, units = "days"))
+  expect_equal(edges$median_duration, as.difftime(4, units = "days"))
+  expect_equal(edges$max_duration, as.difftime(10, units = "days"))
+  expect_equal(edges$min_duration, as.difftime(1, units = "days"))
 })
 
 
@@ -130,10 +130,10 @@ test_that("generate_edges() should count unique 'case_id' if 'distinct_case' is 
   expect_equal(edges$amount, 1)
 
   # test duration
-  expect_equal(edges$mean_duration, "1.21 weeks")
-  expect_equal(edges$median_duration, "1.21 weeks")
-  expect_equal(edges$max_duration, "2.29 weeks")
-  expect_equal(edges$min_duration, "1 days")
+  expect_equal(edges$mean_duration, as.difftime(8.5, units = "days"))
+  expect_equal(edges$median_duration, as.difftime(8.5, units = "days"))
+  expect_equal(edges$max_duration, as.difftime(16, units = "days"))
+  expect_equal(edges$min_duration, as.difftime(1, units = "days"))
 })
 
 test_that("generate_edges() should not count paths from 'target_categories'", {
@@ -161,10 +161,10 @@ test_that("generate_edges() should not count paths from 'target_categories'", {
   expect_equal(edges$amount, 2)
 
   # test duration
-  expect_equal(edges$mean_duration, "1.07 weeks")
-  expect_equal(edges$median_duration, "1.07 weeks")
-  expect_equal(edges$max_duration, "2 weeks")
-  expect_equal(edges$min_duration, "1 days")
+  expect_equal(edges$mean_duration, as.difftime(7.5, units = "days"))
+  expect_equal(edges$median_duration, as.difftime(7.5, units = "days"))
+  expect_equal(edges$max_duration, as.difftime(14, units = "days"))
+  expect_equal(edges$min_duration, as.difftime(1, units = "days"))
 })
 
 test_that("generate_edges() should convert 'timestamp' to 'POSIXct' if it's not 'POSIXct' yet", {
@@ -192,8 +192,29 @@ test_that("generate_edges() should convert 'timestamp' to 'POSIXct' if it's not 
   expect_equal(edges$amount, 2)
 
   # test duration
-  expect_equal(edges$mean_duration, "1.07 weeks")
-  expect_equal(edges$median_duration, "1.07 weeks")
-  expect_equal(edges$max_duration, "2 weeks")
-  expect_equal(edges$min_duration, "1 days")
+  expect_equal(edges$mean_duration, as.difftime(7.5, units = "days"))
+  expect_equal(edges$median_duration, as.difftime(7.5, units = "days"))
+  expect_equal(edges$max_duration, as.difftime(14, units = "days"))
+  expect_equal(edges$min_duration, as.difftime(1, units = "days"))
+})
+
+test_that("generate_edges() should handle the eventlog without timestamp", {
+  edges <- generate_edges(
+    data.frame(
+      case_id = c("c1", "c1", "c1", "c2", "c2", "c3", "c3"),
+      activity = c("a", "b", "a", "b", "b", "a", "b"),
+      category = c("campaign", "sale", "campaign", "sale", "sale", "campaign", "sale"),
+      stringsAsFactors = FALSE
+    )
+  )
+  expect_equal(nrow(edges), 3)
+  expect_equal(edges$from, c("a", "b", "b"))
+  expect_equal(edges$to, c("b", "a", "b"))
+  expect_equal(edges$amount, c(2, 1, 1))
+
+  # test duration
+  expect_equal("mean_duration" %in% colnames(edges), FALSE)
+  expect_equal("median_duration" %in% colnames(edges), FALSE)
+  expect_equal("max_duration" %in% colnames(edges), FALSE)
+  expect_equal("min_duration" %in% colnames(edges), FALSE)
 })


### PR DESCRIPTION
Current edge width is represented for the `amount` attribute of the process map, but we may be more interested in the time cost of the event transfer, so adding `edge_width` option will enable user to choose which attribute to be used for the edge width.